### PR TITLE
media-video/shotcut: depend on virtual/jack

### DIFF
--- a/media-video/shotcut/shotcut-9999.ebuild
+++ b/media-video/shotcut/shotcut-9999.ebuild
@@ -42,9 +42,9 @@ RDEPEND="
 	media-libs/mlt[ffmpeg,frei0r,qt5,sdl,xml]
 	media-libs/x264
 	media-plugins/frei0r-plugins
-	media-sound/jack-audio-connection-kit
 	media-sound/lame
 	media-video/ffmpeg
+	virtual/jack
 "
 
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Please depend on virtual/jack to allow users to install with jack2.

BTW, consider making a repoman payment for the overlay.