### PR TITLE
Add versionator.eclass as a dependency

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-9999.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils desktop flag-o-matic git-r3 gnome2-utils toolchain-funcs xdg
+inherit cmake-utils desktop flag-o-matic git-r3 gnome2-utils toolchain-funcs versionator xdg
 
 DESCRIPTION="Official desktop client for Telegram"
 HOMEPAGE="https://desktop.telegram.org"


### PR DESCRIPTION
Otherwise I get an error:

```
>>> Running pre-merge checks for net-im/telegram-desktop-1.2.21
/var/lib/layman/reagentoo/net-im/telegram-desktop/telegram-desktop-1.2.21.ebuild: line 66: version_is_at_least: command not found
 * ERROR: net-im/telegram-desktop-1.2.21::reagentoo failed (pretend phase):
...
```