### PR TITLE
Add versionator for replace_version_separator func

### DIFF
--- a/net-libs/restbed/restbed-9999.ebuild
+++ b/net-libs/restbed/restbed-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit cmake-utils
+inherit cmake-utils versionator
 
 DESCRIPTION="For applications that require seamless and secure communication over HTTP"
 HOMEPAGE="https://github.com/Corvusoft/${PN}"


### PR DESCRIPTION
Tha same problem as in #13:

```
$ eix-update
...
[3] "reagentoo" /var/lib/layman/reagentoo (cache: parse|ebuild*#metadata-md5#metadata-flat#assign)
     Reading category 108|167 ( 64): net-libs... * ERROR: net-libs/restbed-4.6::reagentoo failed (depend phase):
 *   External commands disallowed while sourcing ebuild: replace_version_separator 2 -
 * 
 * Call stack:
 *            ebuild.sh, line 620:  Called source '/var/lib/layman/reagentoo/net-libs/restbed/restbed-4.6.ebuild'
 *   restbed-4.6.ebuild, line  16:  Called command_not_found_handle 'replace_version_separator' '2' '-'
 *            ebuild.sh, line  88:  Called die
 * The specific snippet of code:
 *   		die "External commands disallowed while sourcing ebuild: ${*}"
```