### PR TITLE
net-im/telegram-desktop: use GNUInstallDirs for cmake files

### DIFF
--- a/net-im/telegram-desktop/files/Telegram.cmake
+++ b/net-im/telegram-desktop/files/Telegram.cmake
@@ -8,6 +8,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+include(GNUInstallDirs)
+
 list(APPEND CMAKE_MODULE_PATH
 	${CMAKE_SOURCE_DIR}/gyp
 	${CMAKE_SOURCE_DIR}/cmake
@@ -199,5 +201,5 @@ if(BUILD_TESTS)
 	include(TelegramTests)
 endif()
 
-install(TARGETS Telegram RUNTIME DESTINATION bin)
-install(PROGRAMS ${CMAKE_SOURCE_DIR}/../lib/xdg/telegram-desktop.desktop DESTINATION share/applications)
+install(TARGETS Telegram RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(PROGRAMS ${CMAKE_SOURCE_DIR}/../lib/xdg/telegram-desktop.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)


### PR DESCRIPTION
Although this isn't necessarily relevant for Gentoo at this
point of time, it does allow us to be a bit more flexible
with our directories (have share in dirs other than
${PREFIX}/share and bin in something other than ${PREFIX}/bin
if we ever desire to do so)

See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
for more info

Please test this on Gentoo as well, as I use Exherbo personally (for which this change is relevant, but it doesn't hurt having it for Gentoo as well). Thanks a lot for creating (and maintaining!) these files though, it helped me greatly in bringing telegram-desktop to Exherbo without having to deal with TG's (slightly) insane build process.