### PR TITLE
net-im/telegram-desktop: move cmake dep to BDEPEND

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-9999.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-9999.ebuild
@@ -47,6 +47,7 @@ REQUIRED_USE="
 	|| ( alsa pulseaudio )
 "
 
+BDEPEND=">=dev-util/cmake-3.16" 
 RDEPEND="
 	app-arch/lz4
 	app-arch/xz-utils
@@ -76,8 +77,6 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
-
-CMAKE_MIN_VERSION="3.16"
 
 pkg_pretend() {
 	if use custom-api-id


### PR DESCRIPTION
Building fails with "CMake 3.16 or higher is required. You are running version 3.14.6".
The ebuild fails to depend on the right cmake version. Placing it above inherit cmake-utils works, but IRC says support for CMAKE_MIN_VERSION is going away so I moved it to BDEPEND.